### PR TITLE
Encode UTF-8 stuff with lossy conversion

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,8 +15,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Install sbt
-        if: matrix.os == 'macos-latest'
-        run: brew install sbt
+        uses: sbt/setup-sbt@v1
       - name: Install Swift
         uses: SwiftyLab/setup-swift@latest
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
           development: true
           swift-version: "5.10"
       - name: Run Linux Build
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           swift build
           mv ./.build/debug/SwiftAstGen SwiftAstGen-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
           development: true
           swift-version: "5.10"
       - name: Run Linux Build
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           swift build -c release --arch arm64 --arch x86_64 --static-swift-stdlib
           mv ./.build/release/SwiftAstGen SwiftAstGen-linux

--- a/Sources/SwiftAstGenLib/SyntaxParser.swift
+++ b/Sources/SwiftAstGenLib/SyntaxParser.swift
@@ -50,6 +50,11 @@ extension SyntaxProtocol {
 
 struct SyntaxParser {
 
+	static func encode(_ s: String) -> String {
+    	let data = s.data(using: .ascii, allowLossyConversion: true)!
+    	return String(data: data, encoding: .utf8)!
+	}
+
 	static func parse(
 		srcDir: URL,
 		fileUrl: URL,
@@ -57,8 +62,9 @@ struct SyntaxParser {
 		prettyPrint: Bool
 	) throws -> String {
 		let code = try String(contentsOf: fileUrl)
+		let content = encode(code)
 		let opPrecedence = OperatorTable.standardOperators
-		let ast = Parser.parse(source: code)
+		let ast = Parser.parse(source: content)
 		let folded = try opPrecedence.foldAll(ast)
 
 		let locationConverter = SourceLocationConverter(fileName: fileUrl.path, tree: folded)
@@ -67,6 +73,7 @@ struct SyntaxParser {
 		treeNode.projectFullPath = srcDir.standardized.resolvingSymlinksInPath().path
 		treeNode.fullFilePath = fileUrl.standardized.resolvingSymlinksInPath().path
 		treeNode.relativeFilePath = relativeFilePath
+		treeNode.content = content
 
 		let encoder = JSONEncoder()
 		if prettyPrint { encoder.outputFormatting = .prettyPrinted }

--- a/Sources/SwiftAstGenLib/TreeNode.swift
+++ b/Sources/SwiftAstGenLib/TreeNode.swift
@@ -3,6 +3,7 @@ final class TreeNode: Codable {
 	var projectFullPath: String?
 	var relativeFilePath: String?
 	var fullFilePath: String?
+	var content: String?
 
 	var index: Int
 	var name: String


### PR DESCRIPTION
Swifts representation of characters beyond 127 differ from what the JVM does. E.g.,  ️⃣  is `\ufe0f\u20e3` in Swift but `\ufe0f\u20e3\u0020` in Scala.