### PR TITLE
Add line count (loc) to TreeNode and JSON output

### DIFF
--- a/Sources/SwiftAstGenLib/TreeNode.swift
+++ b/Sources/SwiftAstGenLib/TreeNode.swift
@@ -4,6 +4,7 @@ final class TreeNode: Codable {
 	var relativeFilePath: String?
 	var fullFilePath: String?
 	var content: String?
+	var loc: Int?
 
 	var index: Int
 	var name: String

--- a/Tests/SwiftAstGenTests/SwiftAstGenTests.swift
+++ b/Tests/SwiftAstGenTests/SwiftAstGenTests.swift
@@ -7,6 +7,7 @@ final class SwiftAstGenTests: XCTestCase, TestUtils {
 	static var allTests = [
 		("testJsonSourceFileSyntax", testJsonSourceFileSyntax),
 		("testJsonFilePaths", testJsonFilePaths),
+		("testJsonLoc", testJsonLoc),
 	]
 
 	func testJsonSourceFileSyntax() throws {
@@ -52,6 +53,31 @@ final class SwiftAstGenTests: XCTestCase, TestUtils {
 
 				XCTAssertEqual(relativeFilePath, "source.swift")
 				XCTAssertEqual(fullFilePath, "\(projectFullPath)/\(relativeFilePath)")
+			} else {
+				XCTFail("Could not create the JSON containing the Swift AST.")
+			}
+		}
+	}
+
+	func testJsonLoc() throws {
+		try withCode(
+			code: """
+					print("1")
+					print("2")
+					print("3")
+				"""
+		) { srcDir, outputDir, jsonFile in
+
+			try SwiftAstGenerator(
+				srcDir: srcDir,
+				outputDir: outputDir,
+				prettyPrint: false
+			).generate()
+
+			XCTAssertTrue(FileManager.default.fileExists(atPath: jsonFile.path))
+			if let treeNode = loadJson(file: jsonFile) {
+				let loc = treeNode.loc!
+				XCTAssertEqual(loc, 3)
 			} else {
 				XCTFail("Could not create the JSON containing the Swift AST.")
 			}


### PR DESCRIPTION
- Introduces a `countLines` utility to `SyntaxParser` to compute the number of lines in source files, handling all common line endings. The resulting line count is stored in the `TreeNode` as the new `loc` property and included in the generated JSON.
- Adds a test to verify correct line count extraction.