### PR TITLE
Remove parallel invocation of AST parsing

### DIFF
--- a/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
+++ b/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
@@ -29,18 +29,6 @@ public class SwiftAstGenerator {
 			|| nameLowercased.contains("/spec/")
 	}
 
-	private func writeStringToFileAsync(string: String, fileUrl: URL) {
-	    DispatchQueue.global(qos: .background).sync {
-            do {
-            	try string.write(
-					to: fileUrl,
-					atomically: true,
-					encoding: String.Encoding.utf8
-				)
-			} catch {}
-        }
-	}
-
 	private func parseFile(fileUrl: URL) {
 		do {
 			let relativeFilePath = fileUrl.relativePath(from: srcDir)!

--- a/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
+++ b/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
@@ -29,13 +29,15 @@ public class SwiftAstGenerator {
 			|| nameLowercased.contains("/spec/")
 	}
 
-	private func writeStringToFileAsync(string: String, toFilePath filePath: String) {
-	    DispatchQueue.global(qos: .background).async {
-	        do {
-	            let data = Data(string.utf8)
-	            let fileURL = URL(fileURLWithPath: filePath)
-	            try data.write(to: fileURL, options: .atomic)
-	        } catch {}
+	private func writeStringToFileAsync(string: String, fileUrl: URL) {
+	    DispatchQueue.global(qos: .background).sync {
+            do {
+            	try string.write(
+					to: fileUrl,
+					atomically: true,
+					encoding: String.Encoding.utf8
+				)
+			} catch {}
         }
 	}
 
@@ -61,7 +63,11 @@ public class SwiftAstGenerator {
 				)
 			}
 
-			writeStringToFileAsync(string: astJsonString, toFilePath: outFileUrl.path)
+			try astJsonString.write(
+				to: outFileUrl,
+				atomically: true,
+				encoding: String.Encoding.utf8
+			)
 	        print("Generated AST for file: `\(fileUrl.path)`")
 		} catch {
 			print("Parsing failed for file: `\(fileUrl.path)` (\(error))")

--- a/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
+++ b/Sources/SwiftAstGenLib/SwiftAstGenerator.swift
@@ -5,10 +5,6 @@ public class SwiftAstGenerator {
 	private var srcDir: URL
 	private var outputDir: URL
 	private var prettyPrint: Bool
-	private let availableProcessors = ProcessInfo.processInfo.activeProcessorCount
-
-	// Private serial queue for directory creation operations
-    private let fileQueue = DispatchQueue(label: "io.joern.swiftastgen")
 
 	public init(srcDir: URL, outputDir: URL, prettyPrint: Bool) throws {
 		self.srcDir = srcDir
@@ -33,6 +29,16 @@ public class SwiftAstGenerator {
 			|| nameLowercased.contains("/spec/")
 	}
 
+	private func writeStringToFileAsync(string: String, toFilePath filePath: String) {
+	    DispatchQueue.global(qos: .background).async {
+	        do {
+	            let data = Data(string.utf8)
+	            let fileURL = URL(fileURLWithPath: filePath)
+	            try data.write(to: fileURL, options: .atomic)
+	        } catch {}
+        }
+	}
+
 	private func parseFile(fileUrl: URL) {
 		do {
 			let relativeFilePath = fileUrl.relativePath(from: srcDir)!
@@ -47,34 +53,22 @@ public class SwiftAstGenerator {
 				.appendingPathExtension("json")
 			let outfileDirUrl = outFileUrl.deletingLastPathComponent()
 
-			do {
-				try fileQueue.sync {
-					try FileManager.default.createDirectory(
-						atPath: outfileDirUrl.path,
-						withIntermediateDirectories: true,
-						attributes: nil
-					)
-				}
-			} catch {}
+			if !FileManager.default.fileExists(atPath: outfileDirUrl.path) {
+				try FileManager.default.createDirectory(
+					atPath: outfileDirUrl.path,
+					withIntermediateDirectories: true,
+					attributes: nil
+				)
+			}
 
-			try astJsonString.write(
-				to: outFileUrl,
-				atomically: true,
-				encoding: String.Encoding.utf8
-			)
-
-			print("Generated AST for file: `\(fileUrl.path)`")
+			writeStringToFileAsync(string: astJsonString, toFilePath: outFileUrl.path)
+	        print("Generated AST for file: `\(fileUrl.path)`")
 		} catch {
 			print("Parsing failed for file: `\(fileUrl.path)` (\(error))")
 		}
 	}
 
 	private func iterateSwiftFiles(at url: URL) {
-		let queue = OperationQueue()
-		queue.name = "SwiftAstGen"
-		queue.qualityOfService = .userInitiated
-		queue.maxConcurrentOperationCount = availableProcessors
-
 		if let enumerator = FileManager.default.enumerator(
 			at: url,
 			includingPropertiesForKeys: [.isRegularFileKey],
@@ -84,15 +78,11 @@ public class SwiftAstGenerator {
 	            if fileAttributes.isRegularFile! && fileURL.pathExtension == "swift" {
 	            	let relativeFilePath = fileURL.relativePath(from: srcDir)!
 	            	if !ignoreDirectory(name: "/\(relativeFilePath)") {
-	            		queue.addOperation {
-	            			self.parseFile(fileUrl: fileURL)
-	            		}
+            			self.parseFile(fileUrl: fileURL)
 	            	}
 	            }
 		    }
 		}
-
-		queue.waitUntilAllOperationsAreFinished()
 	} 
 
 	public func generate() throws {


### PR DESCRIPTION
Crashes when built with x86_64-swift-linux-musl.
We remove it for now until further investigation.