### PR TITLE
Increase stack size on Linux builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,12 @@ let package = Package(
       ],
       swiftSettings: [
         .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
-      ]
+      ],
+      linkerSettings: [
+        // 2M stack size, as swift-linux-musl provides a default thread stack size of only 128k.
+        // This prevents segmentation faults for larger Swift projects being scanned.
+        .unsafeFlags(["-Xlinker", "-z", "-Xlinker", "stack-size=2097152"], .when(platforms: [.linux], configuration: .release))
+      ],
     ),
     .testTarget(
       name: "SwiftAstGenTests",


### PR DESCRIPTION
2M stack size, as swift-linux-musl provides a default thread stack size of only 128k. This prevents segmentation faults for larger Swift projects being scanned.

Can be seen, e.g., with swiftastgen being run on https://github.com/migueldeicaza/SwiftGodot