### PR TITLE
Fix parse failures for files using custom operators

### DIFF
--- a/Sources/SwiftAstGenLib/SyntaxParser.swift
+++ b/Sources/SwiftAstGenLib/SyntaxParser.swift
@@ -73,7 +73,7 @@ struct SyntaxParser {
         let loc = countLines(in: code)
         let opPrecedence = OperatorTable.standardOperators
         let ast = Parser.parse(source: code)
-        let folded = try opPrecedence.foldAll(ast)
+        let folded = opPrecedence.foldAll(ast) { _ in }
 
         let locationConverter = SourceLocationConverter(fileName: fileUrl.path, tree: folded)
         let treeNode = folded.toJson(converter: locationConverter)

--- a/Tests/SwiftAstGenTests/SwiftAstGenTests.swift
+++ b/Tests/SwiftAstGenTests/SwiftAstGenTests.swift
@@ -11,6 +11,7 @@ final class SwiftAstGenTests: XCTestCase, TestUtils {
         ("testIgnoresTestTargetPathsFromPackageSwift", testIgnoresTestTargetPathsFromPackageSwift),
         ("testIgnoresMultipleTestTargetPaths", testIgnoresMultipleTestTargetPaths),
         ("testIgnoresCustomTestTargetPath", testIgnoresCustomTestTargetPath),
+        ("testCustomOperatorDoesNotFailParsing", testCustomOperatorDoesNotFailParsing),
     ]
 
     func testJsonSourceFileSyntax() throws {
@@ -191,6 +192,30 @@ final class SwiftAstGenTests: XCTestCase, TestUtils {
         )
     }
     
+    func testCustomOperatorDoesNotFailParsing() throws {
+        try withCode(
+            code: """
+                infix operator <<<: AdditionPrecedence
+                func <<< (lhs: Int, rhs: Int) -> Int { lhs + rhs }
+                let result = 1 <<< 2
+                """
+        ) { srcDir, outputDir, jsonFile in
+
+            try SwiftAstGenerator(
+                srcDir: srcDir,
+                outputDir: outputDir,
+                prettyPrint: false
+            ).generate()
+
+            XCTAssertTrue(FileManager.default.fileExists(atPath: jsonFile.path))
+            if let treeNode = loadJson(file: jsonFile) {
+                XCTAssertEqual(treeNode.nodeType, "SourceFileSyntax")
+            } else {
+                XCTFail("Could not create the JSON containing the Swift AST.")
+            }
+        }
+    }
+
     func testIgnoresCustomTestTargetPath() throws {
         let tempDir = createTemporaryDirectory()
         defer { cleanup(directory: tempDir) }


### PR DESCRIPTION
Use a non-throwing error handler for operator folding so that unknown operators degrade gracefully (unfolded SequenceExprSyntax) instead of failing the entire file.

Fixes #21